### PR TITLE
Fix dumping to file producing garbage

### DIFF
--- a/source/dyaml/stream.d
+++ b/source/dyaml/stream.d
@@ -58,11 +58,11 @@ class YFile : YStream {
 	}
 
 	void writeExact(const void* buffer, size_t size) {
-		this.file.write(cast(const ubyte[])buffer[0 .. size]);
+		this.file.write(cast(const char[]) buffer[0 .. size]);
 	}
 
 	size_t write(const(ubyte)[] buffer) {
-		this.file.write(buffer);
+		this.file.write(cast(const char[]) buffer);
 		return buffer.length;
 	}
 

--- a/source/dyaml/stream.d
+++ b/source/dyaml/stream.d
@@ -58,11 +58,11 @@ class YFile : YStream {
 	}
 
 	void writeExact(const void* buffer, size_t size) {
-		this.file.write(cast(const char[]) buffer[0 .. size]);
+		this.file.rawWrite(cast(const) buffer[0 .. size]);
 	}
 
 	size_t write(const(ubyte)[] buffer) {
-		this.file.write(cast(const char[]) buffer);
+		this.file.rawWrite(buffer);
 		return buffer.length;
 	}
 


### PR DESCRIPTION
Casting to char[] before writing to a file in YStream seems to fix the problem with the Dumper producing garbage when attempting to dump YAML to a file.

This fixes issue #50 in the original repository.