### PR TITLE
Make Node type identification properties public

### DIFF
--- a/source/dyaml/node.d
+++ b/source/dyaml/node.d
@@ -1631,6 +1631,7 @@ struct Node
             return (cast(nothrowType)&value_.type)();
         }
 
+    public:
         // Determine if the value stored by the node is of specified type.
         //
         // This only works for default YAML types, not for user defined types.
@@ -1639,7 +1640,6 @@ struct Node
             return this.type is typeid(Unqual!T);
         }
 
-    private:
         // Is the value a bool?
         alias isType!bool isBool;
 
@@ -1685,6 +1685,7 @@ struct Node
             else                             {return false;}
         }
 
+    private:
         // Implementation of contains() and containsKey().
         bool contains_(T, Flag!"key" key, string func)(T rhs) const @trusted
         {


### PR DESCRIPTION
Fixes #47 in the original repository.
This makes the isType!T, isString, isInt, isBool, etc. properties on Node public so that it's possible to use them to identify the type of the Node's content without getting a deprecation warning, and presumably eventually an error when the compilers start enforcing the access modifiers.

These are required in order to be able to correctly and accurately deserialize nodes to/from structs and classes (I'm working on a library for this at the moment) without resorting to dirty workarounds like converting everything to string and back again.